### PR TITLE
systemテストにおいて、click後の確実な遷移を確認して進める

### DIFF
--- a/test/system/books_test.rb
+++ b/test/system/books_test.rb
@@ -10,7 +10,9 @@ class BooksTest < ApplicationSystemTestCase
   test '本のCRUD' do # rubocop:disable Metrics/BlockLength
     # 本の登録
     click_link '本'
+    assert_css 'h1', text: '本'
     click_link '新規作成'
+    assert_css 'h1', text: '本の新規作成'
     fill_in 'タイトル', with: 'プロを目指す人のためのRuby入門'
     fill_in 'メモ', with: 'Rubyの文法をサンプルコードで学び、例題でプログラミングの流れを体験できる解説書です。'
     fill_in '著者', with: '伊藤 淳一'
@@ -25,6 +27,7 @@ class BooksTest < ApplicationSystemTestCase
 
     # 本の編集
     click_link '編集'
+    assert_css 'h1', text: '本の編集'
     fill_in 'タイトル', with: 'チェリー本'
     fill_in 'メモ', with: 'Railsをやる前に、Rubyを知ろう'
     fill_in '著者', with: 'jnchito'

--- a/test/system/reports_test.rb
+++ b/test/system/reports_test.rb
@@ -12,7 +12,9 @@ class ReportsTest < ApplicationSystemTestCase
   test '日報のCRUD' do # rubocop:disable Metrics/BlockLength
     # 日報の登録
     click_link '日報'
+    assert_css 'h1', text: '日報'
     click_link '新規作成'
+    assert_css 'h1', text: '日報の新規作成'
     fill_in 'タイトル', with: 'はじめての日報'
     fill_in '内容', with: 'はじめまして。よろしくお願いします。'
     click_button '登録する'
@@ -23,6 +25,7 @@ class ReportsTest < ApplicationSystemTestCase
 
     # 日報の編集
     click_link '編集'
+    assert_css 'h1', text: '日報の編集'
     fill_in 'タイトル', with: 'My first report'
     fill_in '内容', with: 'Hello, everyone!'
     click_button '更新する'


### PR DESCRIPTION
自分のローカル環境で `bundle exec rails test:system` を実施したところ、
遷移が完了する前に `fill_in` の処理が走ってテストが失敗するというケースが見られました。
h1の内容を確認することで遷移完了後に `fill_in` させるとより失敗が減ると思い、提案します。