### PR TITLE
i18nを実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-debug.log*
 
 /public/uploads/*
 .env
+.vscode/*

--- a/Gemfile
+++ b/Gemfile
@@ -36,13 +36,13 @@ group :development, :test do
 end
 
 group :development do
+  gem 'i18n_generators'
   gem 'listen', '~> 3.3'
   gem 'rack-mini-profiler', '~> 2.0'
   gem 'rubocop-fjord', require: false
   gem 'rubocop-rails', require: false
   gem 'spring'
   gem 'web-console', '>= 4.1.0'
-  gem 'i18n_generators'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development do
   gem 'rubocop-rails', require: false
   gem 'spring'
   gem 'web-console', '>= 4.1.0'
+  gem 'i18n_generators'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,9 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    i18n_generators (2.2.2)
+      activerecord (>= 3.0.0)
+      railties (>= 3.0.0)
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -250,6 +253,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   carrierwave
+  i18n_generators
   jbuilder (~> 2.7)
   listen (~> 3.3)
   puma (~> 5.0)

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -28,7 +28,7 @@ class BooksController < ApplicationController
 
     respond_to do |format|
       if @book.save
-        format.html { redirect_to @book, notice: 'Book was successfully created.' }
+        format.html { redirect_to @book, notice: t('notice.create') }
         format.json { render :show, status: :created, location: @book }
       else
         format.html { render :new }
@@ -42,7 +42,7 @@ class BooksController < ApplicationController
   def update
     respond_to do |format|
       if @book.update(book_params)
-        format.html { redirect_to @book, notice: 'Book was successfully updated.' }
+        format.html { redirect_to @book, notice: t('notice.update') }
         format.json { render :show, status: :ok, location: @book }
       else
         format.html { render :edit }
@@ -56,7 +56,7 @@ class BooksController < ApplicationController
   def destroy
     @book.destroy
     respond_to do |format|
-      format.html { redirect_to books_url, notice: 'Book was successfully destroyed.' }
+      format.html { redirect_to books_url, notice: t('notice.destroy') }
       format.json { head :no_content }
     end
   end

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -2,9 +2,5 @@
 
 <%= render 'form', book: @book %>
 
-<%= link_to @book do %>
-  <%= t 'button.show' %>
-<% end %> |
-<%= link_to books_path do %>
-  <%= t 'button.back' %>
-<% end %>
+<%= link_to t('button.show'), @book %> |
+<%= link_to t('button.back'), books_path %>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,6 +1,10 @@
-<h1>Editing Book</h1>
+<h1><%= t('title.update') %></h1>
 
 <%= render 'form', book: @book %>
 
-<%= link_to 'Show', @book %> |
-<%= link_to 'Back', books_path %>
+<%= link_to @book do %>
+  <%= t 'button.show' %>
+<% end %> |
+<%= link_to books_path do %>
+  <%= t 'button.back' %>
+<% end %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -21,19 +21,13 @@
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
         <td>
-          <%= link_to book do %>
-            <%= t 'button.show' %>
-          <% end %>
+          <%= link_to t('button.show'), book %>
         </td>
         <td>
-          <%= link_to edit_book_path(book) do %>
-            <%= t 'button.edit' %>
-          <% end %>
+          <%= link_to t('button.edit'), edit_book_path(book) %>
         </td>
         <td>
-          <%= link_to book, method: :delete, data: { confirm: t('confirm') } do %>
-            <%= t 'button.destroy' %>
-          <% end %>
+          <%= link_to t('button.destroy'), book, method: :delete, data: { confirm: t('confirm')} %>
         </td>
       </tr>
     <% end %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Books</h1>
+<h1><%= t '.book' %></h1>
 
 <table>
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Memo</th>
-      <th>Author</th>
-      <th>Picture</th>
+      <th><%= t '.title' %></th>
+      <th><%= t '.memo' %></th>
+      <th><%= t '.author' %></th>
+      <th><%= t '.picture' %></th>
       <th colspan="3"></th>
     </tr>
   </thead>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p id="notice"><%= notice %></p>
 
-<h1><%= t '.book' %></h1>
+<h1><%= t 'title.books' %></h1>
 
 <table>
   <thead>
     <tr>
-      <th><%= t '.title' %></th>
-      <th><%= t '.memo' %></th>
-      <th><%= t '.author' %></th>
-      <th><%= t '.picture' %></th>
+      <th><%= Book.human_attribute_name(:title) %></th>
+      <th><%= Book.human_attribute_name(:memo) %></th>
+      <th><%= Book.human_attribute_name(:author) %></th>
+      <th><%= Book.human_attribute_name(:picture) %></th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -20,9 +20,21 @@
         <td><%= book.memo %></td>
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
-        <td><%= link_to 'Show', book %></td>
-        <td><%= link_to 'Edit', edit_book_path(book) %></td>
-        <td><%= link_to 'Destroy', book, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td>
+          <%= link_to book do %>
+            <%= t 'button.show' %>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to edit_book_path(book) do %>
+            <%= t 'button.edit' %>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to book, method: :delete, data: { confirm: t('confirm') } do %>
+            <%= t 'button.destroy' %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +42,6 @@
 
 <br>
 
-<%= link_to 'New Book', new_book_path %>
+<%= link_to new_book_path do %>
+  <%= t 'button.new' %>
+<% end %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -2,6 +2,4 @@
 
 <%= render 'form', book: @book %>
 
-<%= link_to books_path do %>
-  <%= t 'button.back' %>
-<% end %>
+<%= link_to t('button.back'), books_path%>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -2,4 +2,6 @@
 
 <%= render 'form', book: @book %>
 
-<%= link_to 'Back', books_path %>
+<%= link_to books_path do %>
+  <%= t 'button.back' %>
+<% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,24 +1,28 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Title:</strong>
+  <strong><%= Book.human_attribute_name(:title) %>:</strong>
   <%= @book.title %>
 </p>
 
 <p>
-  <strong>Memo:</strong>
+  <strong><%= Book.human_attribute_name(:memo) %>:</strong>
   <%= @book.memo %>
 </p>
 
 <p>
-  <strong>Author:</strong>
+  <strong><%= Book.human_attribute_name(:author) %>:</strong>
   <%= @book.author %>
 </p>
 
 <p>
-  <strong>Picture:</strong>
+  <strong><%= Book.human_attribute_name(:picture) %>:</strong>
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
-<%= link_to 'Edit', edit_book_path(@book) %> |
-<%= link_to 'Back', books_path %>
+<%= link_to edit_book_path(@book) do %>
+  <%= t 'button.edit' %>
+<% end %>
+<%= link_to books_path do %>
+  <%= t 'button.back' %>
+<% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -20,9 +20,5 @@
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
-<%= link_to edit_book_path(@book) do %>
-  <%= t 'button.edit' %>
-<% end %>
-<%= link_to books_path do %>
-  <%= t 'button.back' %>
-<% end %>
+<%= link_to t('button.edit'), edit_book_path(@book) %> |
+<%= link_to t('button.back'), books_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module BooksApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    # デフォルトのlocaleを日本語(:ja)にする
+    config.i18n.default_locale = :ja
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,27 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  activerecord:
+    models:
+      book: book
+
+    attributes:
+      book:
+        author: Author
+        memo: Memo
+        picture: picture
+        title: title
+  button:
+    show: show
+    edit: edit
+    back: back
+    destroy: destroy
+    new: new
+  title:
+    books: books
+    create: create
+    update: update
+    destroy: destroy
+  notice:
+    create: Book was successfully created.
+    update: Book was successfully updated.
+    destroy: Book was successfully destroye.
+  confirm: Are you Sure?

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,11 +1,27 @@
 ja:
   activerecord:
     models:
-      book: 本  #g
+      book: 本
 
     attributes:
       book:
-        author: 著者  #g
-        memo: メモ  #g
-        picture: 書籍カバー  #g
-        title: タイトル  #g
+        author: 著者
+        memo: メモ
+        picture: 書籍カバー
+        title: タイトル
+  button:
+    show: 閲覧
+    edit: 編集
+    back: 戻る
+    destroy: 削除
+    new: 作成する
+  title:
+    books: 本一覧
+    create: 本の作成
+    update: 本の編集
+    destroy: 本の削除
+  notice:
+    create: 本を作成しました。
+    update: 本を編集しました。
+    destroy: 本を削除しました。
+  confirm: 本当によろしいですか？

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      book: 本  #g
+
+    attributes:
+      book:
+        author: 著者  #g
+        memo: メモ  #g
+        picture: 書籍カバー  #g
+        title: タイトル  #g


### PR DESCRIPTION
- [x] 英語と日本語の翻訳をconfig/locales配下のYAMLファイルに定義する
- [x] 各画面の表示を翻訳ファイルから取得して表示できるようにする
- [x] デフォルトの表示言語を英語または日本語に切り替えることで、実際に画面の表示が英語と日本語に切り替わる
- [x] 提出時は日本語をデフォルトにすること
- [x] rubocopをパスさせる