### PR TITLE
07-follow_usersでRuboCopをパスさせる

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -70,7 +70,8 @@ end
 
 # 画像は生成も読み込みも時間がかかるので一部のデータだけにする
 User.order(:id).each.with_index(1) do |user, n|
-  next unless n % 8 == 0
+  next unless (n % 8).zero?
+
   image_url = Faker::Avatar.image(slug: user.email, size: '150x150')
   user.avatar.attach(io: URI.parse(image_url).open, filename: 'avatar.png')
 end


### PR DESCRIPTION
d8c791b の変更により、RuboCopがパスしなくなったようです。
プラクティスのスタート時点では警告なしでパスするように修正しました。

ご確認よろしくお願いいたします。