### PR TITLE
bundle update ffi

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     erubi (1.10.0)
-    ffi (1.15.0)
+    ffi (1.15.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.10)


### PR DESCRIPTION
M1 Mac で Active Storage + libvips を使うと ffi でエラーが起きるので fii のバージョンを上げます。
関連 issue, pr: https://github.com/libvips/ruby-vips/issues/284, https://github.com/ffi/ffi/pull/882