### PR TITLE
RubocopのOrderedGemsのエラー解消のためGemfileを修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,6 @@ gem 'net-pop'
 gem 'net-smtp'
 
 gem 'carrierwave'
-gem 'kaminari'
 gem 'devise'
 gem 'devise-i18n'
+gem 'kaminari'


### PR DESCRIPTION
下記のRubocopエラーが発生するため、Gemfileを修正したいです。
```
Gemfile:65:1: C: [Correctable] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile. Gem devise should appear before kaminari.
gem 'devise'
```

下記のPRレビューコメント内で、メンターの田中さんに修正が必要なことを確認しました。
https://github.com/mayumonj/fjord-books_app/pull/4#pullrequestreview-1024148001

`06-user_icon` `07-follow_users` `08-comments`
のブランチで同じエラーが発生するため、`07-follow_users` `08-comments`にも取り込んでいただけますと幸いです。

ご確認お願いできますでしょうか🙇‍♀️